### PR TITLE
Force set cookie if exception occurs when getting cookie

### DIFF
--- a/src/CookieManager/DefaultCookieManager.cs
+++ b/src/CookieManager/DefaultCookieManager.cs
@@ -4,10 +4,10 @@ using Microsoft.AspNetCore.Http;
 
 namespace CookieManager
 {
-	/// <summary>
-	/// Implementation of <see cref="ICookieManager" /> 
-	/// </summary>
-	public class DefaultCookieManager : ICookieManager
+    /// <summary>
+    /// Implementation of <see cref="ICookieManager" /> 
+    /// </summary>
+    public class DefaultCookieManager : ICookieManager
     {
         private readonly ICookie _cookie;
 
@@ -22,30 +22,26 @@ namespace CookieManager
             return _cookie.Contains(key);
         }
 
-		/// <summary>
-		/// Get the value or set the value if specified key is expire
-		/// </summary>
-		/// <typeparam name="T">TSource</typeparam>
-		/// <param name="key">Key</param>
-		/// <param name="acquirer">action to execute</param>
-		/// <param name="expireTime">Expire time</param>
-		/// <returns>TSource object</returns>
-        public T GetOrSet<T>(string key, Func<T> acquirer, int? expireTime = default(int?))
+        /// <summary>
+        /// Get the value or set the value if specified key is expire
+        /// </summary>
+        /// <typeparam name="T">TSource</typeparam>
+        /// <param name="key">Key</param>
+        /// <param name="acquirer">action to execute</param>
+        /// <param name="expireTime">Expire time</param>
+        /// <returns>TSource object</returns>
+        public T GetOrSet<T>(string key, Func<T> acquirer, int? expireTime = default)
         {
-            if(_cookie.Contains(key))
+            try
             {
-                //get the existing value
-               return GetExisting<T>(key);
+                return GetExisting<T>(key);
             }
-            else
-            {
-                var value = acquirer();
-                this.Set(key, value, expireTime);
+            catch { }
 
-                return value;
-            }
+            var value = acquirer();
+            Set(key, value, expireTime);
 
-            return GetExisting<T>(key);
+            return value;
         }
 
         private T GetExisting<T>(string key)
@@ -58,59 +54,55 @@ namespace CookieManager
             return JsonConvert.DeserializeObject<T>(value);
         }
 
-		/// <summary>
-		/// remove the key
-		/// </summary>
-		/// <param name="key"></param>
+        /// <summary>
+        /// remove the key
+        /// </summary>
+        /// <param name="key"></param>
         public void Remove(string key)
         {
             _cookie.Remove(key);
         }
 
-		/// <summary>
-		/// set the value 
-		/// </summary>
-		/// <param name="key">key</param>
-		/// <param name="value">value</param>
-		/// <param name="expireTime"></param>
+        /// <summary>
+        /// set the value 
+        /// </summary>
+        /// <param name="key">key</param>
+        /// <param name="value">value</param>
+        /// <param name="expireTime"></param>
         public void Set(string key, object value, int? expireTime = default(int?))
         {
             _cookie.Set(key, JsonConvert.SerializeObject(value), expireTime);
         }
 
-		
-		/// <summary>
-		/// get the value of specified key
-		/// </summary>
-		/// <typeparam name="T">T object</typeparam>
-		/// <param name="key">Key</param>
-		/// <returns>T object</returns>
-		public T Get<T>(string key)
+
+        /// <summary>
+        /// get the value of specified key
+        /// </summary>
+        /// <typeparam name="T">T object</typeparam>
+        /// <param name="key">Key</param>
+        /// <returns>T object</returns>
+        public T Get<T>(string key)
         {
             return GetExisting<T>(key);
         }
 
-		public void Set(string key, object value, CookieOptions option)
-		{
-			_cookie.Set(key, JsonConvert.SerializeObject(value), option);
-		}
+        public void Set(string key, object value, CookieOptions option)
+        {
+            _cookie.Set(key, JsonConvert.SerializeObject(value), option);
+        }
 
-		public T GetOrSet<T>(string key, Func<T> acquirer, CookieOptions option)
-		{
-			if (_cookie.Contains(key))
-			{
-				//get the existing value
-				return GetExisting<T>(key);
-			}
-			else
-			{
-				var value = acquirer();
-				this.Set(key, value, option);
+        public T GetOrSet<T>(string key, Func<T> acquirer, CookieOptions option)
+        {
+            try
+            {
+                return GetExisting<T>(key);
+            }
+            catch { }
 
-				return value;
-			}
+            var value = acquirer();
+            Set(key, value, option);
 
-			return GetExisting<T>(key);
-		}
-	}
+            return value;
+        }
+    }
 }


### PR DESCRIPTION
Sometimes I get an exception when I want to get a Cookie.
But while using the GetOrSet method, this shouldn't happen.
If the get request fails, the method should set the cookie with the given value (aquirer).
Please provide feedback if this is not the expected behavior.